### PR TITLE
fix loader path

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -11,7 +11,7 @@ use Doctrine\Common\Cache\ApcCache;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
 load: {
-    $dir = dirname(dirname(dirname(__DIR__)));
+    $dir = dirname(__DIR__);
     $loader = require $dir . '/vendor/autoload.php';
     /** @var $loader \Composer\Autoload\ClassLoader */
     $loader->addPsr4(__NAMESPACE__ . '\\', dirname(__DIR__) . '/src');


### PR DESCRIPTION
`composer create-project bear/skeleton ...` すると、
bootstrap スクリプトは `/bootstrap/bootstrap.php` に、
autoloader スクリプトは  `/vendor/autoload.php` に配置されますが、
階層が違うため、autoloaderスクリプトが読み込めずエラーとなります。

こちらの修正を行うPRを送ります。
