### PR TITLE
Enable Annotation in tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 use BEAR\Resource\ResourceInterface;
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use BEAR\Skeleton;
 use BEAR\Skeleton\Module\AppModule;
 use Ray\Di\Injector;
@@ -11,6 +12,7 @@ error_reporting(E_ALL);
 $loader = require dirname(__DIR__) . '/vendor/autoload.php';
 /** @var $loader \Composer\Autoload\ClassLoader */
 $loader->addPsr4('BEAR\Skeleton\\', __DIR__);
+AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 
 // set the application path into the globals so we can access it in the tests.
 $_ENV['TEST_DIR'] = __DIR__;


### PR DESCRIPTION
When I ran phpunit after add annotation, I got below error.

``` bash
$ phpunit
PHP Fatal error:  Uncaught exception 'Doctrine\Common\Annotations\AnnotationException' with message '[Semantical Error] The annotation "@My\App\TestAnnotation" in method My\App\Resource\App\Test::onGet() does not exist, or could not be auto-loaded.' in /path/to/My.App/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationException.php:54
```

This PR fixes this problem.
