### PR TITLE
Remove addPsr4 to autoloader of runtime

### DIFF
--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -13,8 +13,6 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 load: {
     $dir = dirname(__DIR__);
     $loader = require $dir . '/vendor/autoload.php';
-    /** @var $loader \Composer\Autoload\ClassLoader */
-    $loader->addPsr4(__NAMESPACE__ . '\\', dirname(__DIR__) . '/src');
     AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 }
 


### PR DESCRIPTION
In `composer.json`, [`/src` is already added](https://github.com/koriym/BEAR.Skeleton/blob/develop-2/composer.json.dist#L14) so I think this adding on runtime is unnecessary.

(If this runtime adding is purposeful, feel free to reject me :sweat_smile: )
