### PR TITLE
Bind AppInterface to my own App

### DIFF
--- a/src/Module/AppModule.php
+++ b/src/Module/AppModule.php
@@ -4,6 +4,7 @@ namespace BEAR\Skeleton\Module;
 
 use BEAR\Package\AppMeta;
 use BEAR\Package\PackageModule;
+use BEAR\Sunday\Extension\Application\AppInterface;
 use Ray\Di\AbstractModule;
 
 class AppModule extends AbstractModule
@@ -13,6 +14,8 @@ class AppModule extends AbstractModule
      */
     protected function configure()
     {
+        $this->bind(AppInterface::class)->to(App::class);
+
         $this->install(new PackageModule(new AppMeta('BEAR\Skeleton')));
     }
 }


### PR DESCRIPTION
In this skeleton [own App exists](https://github.com/koriym/BEAR.Skeleton/blob/develop-2/src/Module/App.php), so I think AppInterface should be binded to this.

Now AppInterface is binded to [MinApp](https://github.com/koriym/BEAR.Sunday/blob/develop-2/src/Module/SundayModule.php#L26) via [PackageModule](https://github.com/koriym/BEAR.Skeleton/blob/develop-2/src/Module/AppModule.php#L16).
