### PR TITLE
resolve 'No such file or directory' error when unlink composer.lock

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -43,7 +43,6 @@ class Installer
 
         // composer.json
         unlink("{$skeletonRoot}/composer.json");
-        unlink("{$skeletonRoot}/composer.lock");
         rename("{$skeletonRoot}/composer.json.dist", "{$skeletonRoot}/composer.json");
         $composerJson = file_get_contents("{$skeletonRoot}/composer.json");
         $packageNameComposerJson = str_replace('bear/skeleton', strtolower("{$vendorName}/{$packageName}"), $composerJson);


### PR DESCRIPTION
https://github.com/bearsunday/BEAR.Skeleton/commit/55f1e31a0d2f3b47653afb39973d5064297fb9fc

でcomposer.lockをunlinkする処理が追加されていますが、プロジェクト作成時に以下のエラーが発生します。

```
$ composer create-project bear/skeleton:~1.0@dev MyVendor.MyPackage
Installing bear/skeleton (1.0.x-dev 3187d61fb91027be8e01373aee64b52e7c99f07f)
  - Installing bear/skeleton (1.0.x-dev 3187d61)
    Cloning 3187d61fb91027be8e01373aee64b52e7c99f07f

Created project in MyVendor.MyPackage
Loading composer repositories with package information
Installing dependencies (including require-dev)
Nothing to install or update
Generating autoload files
Script BEAR\Skeleton\Installer::postInstall handling the post-install-cmd event terminated with an exception



  [ErrorException]                                                                          
  unlink(/Users/Yuu/workspace/MyVendor.MyPackage/composer.lock): No such file or directory  



create-project [-s|--stability="..."] [--prefer-source] [--prefer-dist] [--repository-url="..."] [--dev] [--no-dev] [--no-plugins] [--no-custom-installers] [--no-scripts] [--no-progress] [--keep-vcs] [--no-install] [package] [directory] [version]
```
