### PR TITLE
resolve 'No such file or directory' error when scandir vendor

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -50,15 +50,6 @@ class Installer
         $packageNameComposerJson = str_replace('BEAR\\\\Skeleton\\\\', "{$vendorName}\\\\{$packageName}\\\\", $packageNameComposerJson);
         file_put_contents("{$skeletonRoot}/composer.json", $packageNameComposerJson);
 
-        // remove ./vendor
-        $unlink = function ($dir) use (&$unlink) {
-            foreach(scandir($dir) as $file) {
-                if ('.' === $file || '..' === $file) continue;
-                is_dir("$dir/$file") ? $unlink("$dir/$file") : unlink("$dir/$file");
-            }
-            rmdir($dir);
-        };
-        $unlink($skeletonRoot . '/vendor');
         unlink($skeletonRoot . '/README.md');
         unlink(__FILE__);
     }


### PR DESCRIPTION
```
PHP Warning:  scandir(/Users/Yuu/workspace/Vender.Package/vendor): failed to open dir: No such file or directory in /Users/Yuu/workspace/Vender.Package/src/Installer.php on line 55

Warning: scandir(/Users/Yuu/workspace/Vender.Package/vendor): failed to open dir: No such file or directory in /Users/Yuu/workspace/Vender.Package/src/Installer.php on line 55
PHP Warning:  scandir(): (errno 2): No such file or directory in /Users/Yuu/workspace/Vender.Package/src/Installer.php on line 55

Warning: scandir(): (errno 2): No such file or directory in /Users/Yuu/workspace/Vender.Package/src/Installer.php on line 55
PHP Warning:  Invalid argument supplied for foreach() in /Users/Yuu/workspace/Vender.Package/src/Installer.php on line 55

Warning: Invalid argument supplied for foreach() in /Users/Yuu/workspace/Vender.Package/src/Installer.php on line 55
PHP Warning:  rmdir(/Users/Yuu/workspace/Vender.Package/vendor): No such file or directory in /Users/Yuu/workspace/Vender.Package/src/Installer.php on line 59

Warning: rmdir(/Users/Yuu/workspace/Vender.Package/vendor): No such file or directory in /Users/Yuu/workspace/Vender.Package/src/Installer.php on line 59
```
