### PR TITLE
fix QA problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@
 build/
 nbproject
 vendor
+var/log/*
+var/tmp/*
+tests/tmp/*
+
+!.placefolder

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,35 @@
+<?php
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+->in(__DIR__);
+
+$config = Symfony\CS\Config\Config::create()
+->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+->finder($finder)
+->fixers(
+    [
+        'extra_empty_lines',
+        'no_blank_lines_after_class_opening',
+        'no_empty_lines_after_phpdocs',
+        'operators_spaces',
+        'phpdoc_indent',
+        'phpdoc_no_empty_return',
+        'phpdoc_no_package',
+        'phpdoc_params',
+        'phpdoc_separation',
+        'phpdoc_to_comment',
+        'phpdoc_trim',
+        'phpdoc_var_without_name',
+        'remove_leading_slash_use',
+        'remove_lines_between_uses',
+        'return',
+        'single_array_no_trailing_comma',
+        'spaces_before_semicolon',
+        'spaces_cast',
+        'standardize_not_equal',
+        'ternary_spaces',
+        'whitespacy_lines',
+        'ordered_use',
+        'short_array_syntax'
+    ]
+);
+return $config;

--- a/.php_cs
+++ b/.php_cs
@@ -1,5 +1,6 @@
 <?php
 $finder = Symfony\CS\Finder\DefaultFinder::create()
+->exclude(['var/tmp', 'tests/tmp'])
 ->in(__DIR__);
 
 $config = Symfony\CS\Config\Config::create()

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "composer/composer": "~1.0",
         "phpunit/phpunit": "~4.8 || ~5.2",
         "squizlabs/php_codesniffer": "~2.5",
-        "phpmd/phpmd": "~2.3"
+        "phpmd/phpmd": "~2.3",
+        "fabpot/php-cs-fixer": "~1.11"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -22,4 +22,5 @@
     </rule>
     <file>src</file>
     <file>tests</file>
+    <exclude-pattern>tests/tmp/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
コミットコメントの通り以下の修正を行いました。ご確認をお願いします。
- Fix `[RuntimeException] Error Output: sh: php-cs-fixer: command not found` error when executing `compoer cs-fix`
  - `fabpot/php-cs-fixer`が依存ライブラリ(require-dev)に含まれていないため、追加しました
  - `.php_cs`が存在しないため、bearsundayプロジェクト（Sunday, Resource, Packageで同じ内容）のものを追加しました
- Exclude temporary files
  - `composer create-project`後のアプリ/テスト実行時に生成される一時ファイルを、
    - git管理から除外しました
    - 静的解析の対象から除外しました
