### PR TITLE
Change bootstrap anonymous function

### DIFF
--- a/bootstrap/api.php
+++ b/bootstrap/api.php
@@ -1,3 +1,3 @@
 <?php
-$context = PHP_SAPI === 'cli' ? 'cli-hal-api-app' : 'hal-api-app';
-require __DIR__ . '/bootstrap.php';
+require dirname(__DIR__) . '/autoload.php';
+exit((require __DIR__ . '/bootstrap.php')(PHP_SAPI === 'cli' ? 'cli-hal-api-app' : 'hal-api-app'));

--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -1,9 +1,9 @@
-<?php declare(strict_types=1);
+<?php
 use BEAR\Package\Bootstrap;
 use BEAR\Resource\ResourceObject;
 
-return function (string $context) : int {
-    $app = (new Bootstrap)->getApp('BEAR\Skeleton', $context, dirname(__DIR__));
+return function (string $context, string $name = 'BEAR\Skeleton') : int {
+    $app = (new Bootstrap)->getApp($name, $context, dirname(__DIR__));
     $request = $app->router->match($GLOBALS, $_SERVER);
     try {
         $response = $app->resource->{$request->method}->uri($request->path)($request->query);

--- a/bootstrap/bootstrap.php
+++ b/bootstrap/bootstrap.php
@@ -1,18 +1,17 @@
-<?php
+<?php declare(strict_types=1);
 use BEAR\Package\Bootstrap;
 use BEAR\Resource\ResourceObject;
 
-require dirname(__DIR__) . '/autoload.php';
-
-/* @global string $context */
-$app = (new Bootstrap)->getApp('BEAR\Skeleton', $context, dirname(__DIR__));
-$request = $app->router->match($GLOBALS, $_SERVER);
-try {
-    $page = $app->resource->{$request->method}->uri($request->path)($request->query);
-    /* @var ResourceObject $page */
-    $page->transfer($app->responder, $_SERVER);
-    exit(0);
-} catch (\Exception $e) {
-    $app->error->handle($e, $request)->transfer();
-    exit(1);
-}
+return function (string $context) : int {
+    $app = (new Bootstrap)->getApp('BEAR\Skeleton', $context, dirname(__DIR__));
+    $request = $app->router->match($GLOBALS, $_SERVER);
+    try {
+        $response = $app->resource->{$request->method}->uri($request->path)($request->query);
+        /* @var ResourceObject $response */
+        $response->transfer($app->responder, $_SERVER);
+        return 0;
+    } catch (\Exception $e) {
+        $app->error->handle($e, $request)->transfer();
+        return 1;
+    }
+};

--- a/bootstrap/web.php
+++ b/bootstrap/web.php
@@ -1,3 +1,3 @@
 <?php
-$context = PHP_SAPI === 'cli' ? 'cli-hal-app' : 'hal-app';
-require __DIR__ . '/bootstrap.php';
+require dirname(__DIR__) . '/autoload.php';
+exit((require __DIR__ . '/bootstrap.php')(PHP_SAPI === 'cli' ? 'cli-hal-app' : 'hal-app'));

--- a/public/index.php
+++ b/public/index.php
@@ -1,3 +1,3 @@
 <?php
-$context = PHP_SAPI === 'cli-server' ? 'hal-app' : 'prod-hal-app';
-require dirname(__DIR__) . '/bootstrap/bootstrap.php';
+require dirname(__DIR__) . '/autoload.php';
+exit((require dirname(__DIR__) . '/bootstrap/bootstrap.php')(PHP_SAPI === 'cli-server' ? 'hal-app' : 'prod-hal-app'));


### PR DESCRIPTION
 Make bootstrap.php from plain script to anonymous function.

 * Easier customization in each context for initialization or finalization
 * Keep the global namespace clean

bootstrap.php
```php
<?php 
use BEAR\Package\Bootstrap;
use BEAR\Resource\ResourceObject;

return function (string $context) : int {
    $app = (new Bootstrap)->getApp('BEAR\Skeleton', $context, dirname(__DIR__));
    $request = $app->router->match($GLOBALS, $_SERVER);
    try {
        $response = $app->resource->{$request->method}->uri($request->path)($request->query);
        /* @var ResourceObject $response */
        $response->transfer($app->responder, $_SERVER);
        return 0;
    } catch (\Exception $e) {
        $app->error->handle($e, $request)->transfer();
        return 1;
    }
};

```

web.php
```php
<?php
require dirname(__DIR__) . '/autoload.php';
// init here
$code = (require __DIR__ . '/bootstrap.php')(PHP_SAPI === 'cli' ? 'cli-hal-app' : 'hal-app');
// finalization here
exit($code);
```