### PR TITLE
Load env file only if it exists

### DIFF
--- a/src/Module/AppModule.php
+++ b/src/Module/AppModule.php
@@ -13,7 +13,10 @@ class AppModule extends AbstractModule
     protected function configure()
     {
         $appDir = dirname(__DIR__, 2);
-        (new Loader($appDir . '/.env'))->parse()->toEnv(true);
+        $env = $appDir . '/.env';
+        if (file_exists($env)) {
+            (new Loader($env))->parse()->toEnv(true);
+        }
         $this->install(new PackageModule);
     }
 }


### PR DESCRIPTION
 * In production, `.env` is not always used.
 * It is problematic when project installed as a composer library.

This PR makes no exception thrown when `.env` file is not exist.