### PR TITLE
Merge env.php to AppModule

### DIFF
--- a/env.php
+++ b/env.php
@@ -1,7 +1,0 @@
-<?php
-use josegonzalez\Dotenv\Loader;
-
-$env = __DIR__ . '/.env';
-if (file_exists($env)) {
-    (new Loader($env))->parse()->putenv();
-}

--- a/src/Module/AppModule.php
+++ b/src/Module/AppModule.php
@@ -3,6 +3,7 @@ namespace BEAR\Skeleton\Module;
 
 use BEAR\Package\AbstractAppModule;
 use BEAR\Package\PackageModule;
+use josegonzalez\Dotenv\Loader;
 
 class AppModule extends AbstractAppModule
 {
@@ -12,7 +13,14 @@ class AppModule extends AbstractAppModule
     protected function configure()
     {
         $appDir = $this->appMeta->appDir;
-        require_once $appDir . '/env.php';
+        $this->loadEnv($appDir . '/.env');
         $this->install(new PackageModule);
+    }
+
+    private function loadEnv(string $env)
+    {
+        if (file_exists($env)) {
+            (new Loader($env))->parse()->putenv();
+        }
     }
 }


### PR DESCRIPTION
The default AppModule looks like this.

```php
class AppModule extends AbstractAppModule
{
    /**
     * {@inheritdoc}
     */
    protected function configure()
    {
        $appDir = $this->appMeta->appDir;
        $this->loadEnv();
        $this->install(new PackageModule);
    }
    
    private function loadEnv()
    {
        $env = __DIR__ . '/.env';
        if (file_exists($env)) {
            (new Loader($env))->parse()->putenv();
        }
    }
}
```