### PR TITLE
Change PHP support version 7.1, 7.2, Update composer package version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,24 @@
 language: php
 sudo: false
+
 php:
-  - 7
+  - 7.1
+  - 7.2
+
 cache:
   directories:
     - vendor
     - $HOME/.composer/cache
-before_script:
+
+matrix:
+  fast_finish: true
+
+before_install:
   - composer self-update
+
+install:
   - composer update --no-scripts
   - composer dump-autoload
+
 script:
   - php bin/page.php get /

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,14 @@
     "license":"MIT",
     "description": "Skeleton application for BEAR.Sunday",
     "require": {
-        "php": "7.0.*",
+        "php": ">=7.1 <7.3",
         "bear/package": "^1.9",
         "josegonzalez/dotenv": "^3.2"
     },
     "require-dev": {
-        "bear/qatools": "^1.7",
+        "bear/qatools": "^1.9",
         "roave/security-advisories": "dev-master",
-        "composer/composer": "^1.7.1"
+        "composer/composer": "^1.8.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## 変更内容

- PHPバージョンを `7.0` から `7.1` と `7.2` に変更しました（ `7.3` は指定するとパッケージ `bear/qatools` の依存解決エラーになったため外してあります）
- Composer package "bear/qatools", "composer/composer" のバージョン指定を変更しました

## Link

https://github.com/bearsunday/BEAR.Skeleton/issues/80

## 気になる点

下記のとおり、以前、意図的にPHP7.0 へのダウングレードが行われていたようなので、特に問題が無いかが気になりました。

https://github.com/bearsunday/BEAR.Skeleton/pull/78/files

## 検証記録

ローカル環境PHP7.1で、下記の手順でインストール（アプリケーションプロジェクト作成）を行い、問題なくアプリケーション作成できる（テストが成功する）のを確認しました。

```
composer create-project --stability="dev" --repository-url="/path/to/my/v1.7.2.beta/package.json" -n bear/skeleton app-dev
```

package.json 内容
```
{
    "package": {
        "name": "bear/skeleton",
        "version": "1.7.2.beta",
        "source": {
            "url": "git@github.com:kumamidori/BEAR.Skeleton.git",
            "type": "git",
            "reference": "feature/php71_20190219"
        }
    }
}
```
