### PR TITLE
Set the 1st argument of Dotenv to true

### DIFF
--- a/src/Module/AppModule.php
+++ b/src/Module/AppModule.php
@@ -14,7 +14,7 @@ class AppModule extends AbstractAppModule
 {
     protected function configure(): void
     {
-        (new Dotenv())->loadEnv(dirname(__DIR__, 2) . '/.env');
+        (new Dotenv(true))->loadEnv(dirname(__DIR__, 2) . '/.env');
         $this->install(new PackageModule());
     }
 }


### PR DESCRIPTION
5.1からDotenvの第一引数が変わり、デフォルトだとusePutenvがfalseになってしまうため、trueを設定
（getenvが使えなくなってしまうので）
もしくは `(new Dotenv())->usePutenv()->loadEnv(...` でも良いと思います

https://github.com/symfony/dotenv/commit/e1f27138406a700c01d4e05e861226bb0c28b83a#diff-a6967492da82dce9ba93bcba3eee0334R46
https://github.com/symfony/symfony/issues/31765