### PR TITLE
Fix port number type

### DIFF
--- a/bin/swoole.php
+++ b/bin/swoole.php
@@ -12,5 +12,5 @@ exit((require $bootstrap)(
     'prod-app',
     'BEAR\Skeleton',
     '127.0.0.1',
-    '8080'
+    8080
 ));


### PR DESCRIPTION
In BEAR.Swoole bootstrap, `$port` must be type of int.

https://github.com/bearsunday/BEAR.Swoole/blob/master/bootstrap.php#L22