### PR TITLE
Update bear/api-doc to ^1.7

### DIFF
--- a/apidoc.xml
+++ b/apidoc.xml
@@ -5,7 +5,7 @@
     <appName>BEAR\Skeleton</appName>
     <scheme>app</scheme>
     <docDir>docs</docDir>
-    <format>html</format>
+    <format>html,openapi,llms</format>
     <title>BEAR.Skeleton API</title>
     <description>API Document</description>
 </apidoc>

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "ray/di": "^2.14"
     },
     "require-dev": {
-        "bear/api-doc": "^1.1",
+        "bear/api-doc": "^1.7",
         "bear/devtools": "^1.0",
         "bear/security": "^0.1",
         "bamarni/composer-bin-plugin": "^1.4",


### PR DESCRIPTION
- Update bear/api-doc from ^1.1 to ^1.7
- Enable multiple output formats: `html,openapi,llms`