### PR TITLE
Add security and apidoc workflows, enable CI triggers

### DIFF
--- a/.github/workflows/alps.yml
+++ b/.github/workflows/alps.yml
@@ -1,0 +1,38 @@
+name: ALPS
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  alps:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install -g @alps-asd/app-state-diagram
+      - name: Generate ALPS diagram
+        run: |
+          if [ -f "docs/alps.json" ]; then
+            asd docs/alps.json
+          elif [ -f "docs/alps.xml" ]; then
+            asd docs/alps.xml
+          else
+            echo "::error::No ALPS profile found (docs/alps.json or docs/alps.xml)"
+            exit 1
+          fi
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -1,0 +1,10 @@
+name: API Documentation
+
+on:
+  workflow_dispatch:
+
+jobs:
+  apidoc:
+    uses: bearsunday/BEAR.ApiDoc/.github/workflows/apidoc.yml@1.x
+    with:
+      format: 'html,openapi,llms'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,9 @@
 name: Continuous Integration
 
 on:
+  push:
+    branches: [1.x]
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -13,7 +16,7 @@ jobs:
         operating-system:
           - ubuntu-latest
         php-version:
-          - '8.4'
+          - '8.5'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,24 +1,20 @@
-name: Coding Standards
+name: Security
 
 on:
   workflow_dispatch:
-  workflow_call:
 
 jobs:
-  coding-standards:
-    name: Coding Standards
+  taint-analysis:
+    name: Psalm Taint Analysis
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.5'
-          tools: cs2pr
           coverage: none
 
       - name: Get composer cache directory
@@ -33,12 +29,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
+        run: composer install --no-progress --prefer-dist --no-interaction
 
-      - name: Validate composer.json
-        run: |
-          composer update
-          composer validate --strict
-
-      - name: Run PHP_CodeSniffer
-        run: ./vendor/bin/phpcs -q --no-colors --report=checkstyle src tests | cs2pr
+      - name: Run Psalm Taint Analysis
+        run: ./vendor/bin/psalm --taint-analysis src

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: '8.5'
           tools: cs2pr
           coverage: none
 
@@ -45,7 +45,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: '8.5'
 
       - name: Get composer cache directory
         id: composer-cache
@@ -74,7 +74,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: '8.5'
           coverage: none
 
       - name: Get composer cache directory

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,6 +7,7 @@
     findUnusedBaselineEntry="false"
     findUnusedCode="false"
     reportUnusedSuppressions="false"
+    runTaintAnalysis="true"
 >
     <projectFiles>
         <directory name="src"/>
@@ -39,4 +40,16 @@
             </errorLevel>
         </ClassMustBeFinal>
     </issueHandlers>
+    <stubs>
+        <file name="vendor/bear/security/stubs/AuraSql.phpstub"/>
+        <file name="vendor/bear/security/stubs/PDO.phpstub"/>
+        <file name="vendor/bear/security/stubs/Qiq.phpstub"/>
+    </stubs>
+    <plugins>
+        <pluginClass class="BEAR\Security\Psalm\ResourceTaintPlugin">
+            <targets>
+                <target>Page</target>
+            </targets>
+        </pluginClass>
+    </plugins>
 </psalm>

--- a/src/Install.php
+++ b/src/Install.php
@@ -22,7 +22,6 @@ use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
 use function getenv;
-use function glob;
 use function in_array;
 use function is_dir;
 use function is_string;
@@ -30,7 +29,6 @@ use function is_writable;
 use function phpversion;
 use function preg_replace;
 use function rename;
-use function rmdir;
 use function sprintf;
 use function str_replace;
 use function strtolower;
@@ -154,21 +152,9 @@ final class Install
         chmod($projectRoot . '/var/log', 0775);
         $this->recursiveJob($projectRoot, $this->rename($vendor, $project));
         unlink($projectRoot . '/README.md');
-        $wfDir = dirname(__DIR__) . '/.github';
-        $this->deleteFiles($wfDir);
-        rmdir($wfDir);
         rename($projectRoot . '/README.proj.md', $projectRoot . '/README.md');
         rename($projectRoot . '/.gitattributes.txt', $projectRoot . '/.gitattributes');
         $this->replaceFile('{php_version}', (string) PHP_VERSION_ID, $projectRoot . '/phpcs.xml');
-    }
-
-    /** @SuppressWarnings("PHPMD.ErrorControlOperator") */
-    private function deleteFiles(string $path): void
-    {
-        foreach (array_filter((array) glob($path . '/*')) as $file) {
-            is_dir($file) ? $this->deleteFiles($file) : unlink($file);
-            @rmdir($file);
-        }
     }
 
     private function replaceFile(string $search, string $replace, string $file): void


### PR DESCRIPTION
## Summary
- Add security.yml for Psalm taint analysis (workflow_dispatch only)
- Add apidoc.yml using BEAR.ApiDoc reusable workflow (workflow_dispatch only)
- Enable push/PR triggers for continuous-integration.yml (for issue reproduction repos)
- Update all workflows to PHP 8.5
- Keep .github directory on project installation (remove deletion from Install.php)