### PR TITLE
Fix coding standards failures

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,7 +3,11 @@ name: Continuous Integration
 on:
   push:
     branches: [1.x]
+    paths-ignore:
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 jobs:

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -6,8 +6,6 @@ namespace BEAR\Skeleton;
 
 use Composer\Script\Event;
 
-use function dirname;
-use function passthru;
 use function unlink;
 
 final class Composer

--- a/src/Install.php
+++ b/src/Install.php
@@ -13,7 +13,6 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
 
-use function array_filter;
 use function array_merge;
 use function assert;
 use function chmod;

--- a/src/Module/AppModule.php
+++ b/src/Module/AppModule.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace BEAR\Skeleton\Module;
 
-use Koriym\EnvJson\EnvJson;
 use BEAR\Package\AbstractAppModule;
 use BEAR\Package\PackageModule;
+use Koriym\EnvJson\EnvJson;
 
 use function dirname;
 

--- a/tests/Resource/Page/IndexTest.php
+++ b/tests/Resource/Page/IndexTest.php
@@ -6,7 +6,6 @@ namespace BEAR\Skeleton\Resource\Page;
 
 use BEAR\Resource\ResourceInterface;
 use BEAR\Skeleton\Injector;
-use BEAR\Skeleton\Resource\Page\Index;
 use PHPUnit\Framework\TestCase;
 
 use function assert;


### PR DESCRIPTION
## Summary
- Remove unused function imports reported by PHP_CodeSniffer
- Sort imports in AppModule
- Remove a same-namespace import from the resource test

## Validation
- zsh -ic 'sphp85; composer tests'