### PR TITLE
Add Docker development environment with Xdebug

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.idea
+vendor
+vendor-bin/**/vendor
+build
+docs/api
+var/log/*
+var/tmp/*
+.phpunit.cache
+.phpunit.result.cache
+.phpcs-cache
+composer.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM php:8.3-cli
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip libzip-dev \
+    && docker-php-ext-install zip \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY docker/php/conf.d/xdebug.ini /usr/local/etc/php/conf.d/99-xdebug.ini
+
+ENV XDEBUG_MODE=off \
+    XDEBUG_START_WITH_REQUEST=trigger \
+    XDEBUG_CLIENT_HOST=host.docker.internal \
+    XDEBUG_CLIENT_PORT=9003 \
+    PHP_IDE_CONFIG=serverName=BEAR.Skeleton
+
+WORKDIR /app
+EXPOSE 8080
+
+CMD ["php", "-S", "0.0.0.0:8080", "-t", "public"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,41 @@ composer create-project bear/skeleton path/to/install
 
 * Documentation http://bearsunday.github.io/
 
+# Docker development
+
+Build the development image and install dependencies inside the container:
+
+```bash
+docker compose build
+docker compose run --rm app composer install
+```
+
+Start the built-in PHP server:
+
+```bash
+docker compose up
+```
+
+The app is available at http://127.0.0.1:8080/. You can also run CLI requests through Docker:
+
+```bash
+docker compose run --rm app php bin/page.php get /
+```
+
+Xdebug is installed but disabled by default. Enable it only when debugging:
+
+```bash
+XDEBUG_MODE=debug,develop XDEBUG_START_WITH_REQUEST=yes docker compose up
+```
+
+For CLI debugging:
+
+```bash
+XDEBUG_MODE=debug,develop XDEBUG_START_WITH_REQUEST=yes docker compose run --rm app php bin/page.php get /
+```
+
+Use port `9003` in your IDE and map the project root to `/app`. The default `PHP_IDE_CONFIG` server name is `BEAR.Skeleton`.
+
 ## How to test the skeleton itself
 
 1. Make sure every files are commited.

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,24 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    working_dir: /app
+    volumes:
+      - .:/app
+      - var-tmp:/app/var/tmp
+      - var-log:/app/var/log
+    ports:
+      - "8080:8080"
+    environment:
+      XDEBUG_MODE: ${XDEBUG_MODE:-off}
+      XDEBUG_START_WITH_REQUEST: ${XDEBUG_START_WITH_REQUEST:-trigger}
+      XDEBUG_CLIENT_HOST: ${XDEBUG_CLIENT_HOST:-host.docker.internal}
+      XDEBUG_CLIENT_PORT: ${XDEBUG_CLIENT_PORT:-9003}
+      PHP_IDE_CONFIG: ${PHP_IDE_CONFIG:-serverName=BEAR.Skeleton}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+volumes:
+  var-tmp:
+  var-log:

--- a/docker/php/conf.d/xdebug.ini
+++ b/docker/php/conf.d/xdebug.ini
@@ -1,0 +1,6 @@
+xdebug.mode=${XDEBUG_MODE}
+xdebug.start_with_request=${XDEBUG_START_WITH_REQUEST}
+xdebug.client_host=${XDEBUG_CLIENT_HOST}
+xdebug.client_port=${XDEBUG_CLIENT_PORT}
+xdebug.discover_client_host=0
+xdebug.log_level=0


### PR DESCRIPTION
## Summary
- add a development Dockerfile and compose.yaml for BEAR.Skeleton
- install Xdebug in the image while keeping it disabled by default
- document server, CLI, and Xdebug usage
- keep generated var/tmp and var/log writes in Docker named volumes

## Verification
- composer validate --no-check-publish
- docker compose config

Note: docker compose build could not be completed on this machine because the local Docker builder returned `failed to create lease: read-only file system`.