### PR TITLE
Use Meta path overrides and Compiler::fromInjector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.15.0] - 2026-07-10
 
 ### Added
-- `bin/compile.php` using `Compiler::fromInjector(Injector::getInstance($context), $context)->run()`
+- `bin/compile.php`: `Compiler::fromInjector(Injector::getInstance($context), $context)->run()`
 
 ### Changed
-- `Injector` builds `Meta` explicitly and accepts optional `$tmpDir` / `$logDir` (defaults unchanged)
+- `Injector` builds `Meta`; optional `$tmpDir` / `$logDir` (null = `{appDir}/var/{tmp|log}/{context}`)
 - Require `bear/app-meta` `^1.11` and `bear/package` `^1.21`
-- `composer compile` script uses `php bin/compile.php` instead of `bear.compile`
+- `composer compile` uses `php bin/compile.php` instead of `bear.compile`
 
 ## [1.14.0] - 2026-01-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.15.0] - 2026-07-10
 
 ### Added
-- `bin/compile.php` using `Compiler::fromInjector()` + `run()` (`$tmpDir` / `$logDir` default to null = Meta paths)
+- `bin/compile.php` using `Compiler::fromInjector(Injector::getInstance($context), $context)->run()`
 
 ### Changed
 - `Injector` builds `Meta` explicitly and accepts optional `$tmpDir` / `$logDir` (defaults unchanged)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.15.0] - 2026-07-10
 
 ### Added
-- `bin/compile.php`: `Compiler::fromInjector(Injector::getInstance($context), $context)->run()`
+- `bin/compile.php`: `Compiler::fromInjector(Injector::getInstance($context), $context)()`
 
 ### Changed
 - `Injector` builds `Meta`; optional `$tmpDir` / `$logDir` (null = `{appDir}/var/{tmp|log}/{context}`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `bin/compile.php`: `Compiler::fromInjector(Injector::getInstance($context), $context)()`
 
 ### Changed
-- Require `bear/package` `^1.21`
+- `Injector::getInstance` builds `Meta` (optional `$tmpDir` / `$logDir` pass-through)
+- Require `bear/app-meta` `^1.11` and `bear/package` `^1.21`
 - `composer compile` uses `php bin/compile.php` instead of `bear.compile`
 
 ## [1.14.0] - 2026-01-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `bin/compile.php`: `Compiler::fromInjector(Injector::getInstance($context), $context)()`
 
 ### Changed
-- `Injector` builds `Meta`; optional `$tmpDir` / `$logDir` (null = `{appDir}/var/{tmp|log}/{context}`)
-- Require `bear/app-meta` `^1.11` and `bear/package` `^1.21`
+- Require `bear/package` `^1.21`
 - `composer compile` uses `php bin/compile.php` instead of `bear.compile`
 
 ## [1.14.0] - 2026-01-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.15.0] - 2026-07-10
 
 ### Added
-- `bin/compile.php` using `Compiler::fromInjector()` + `run()` (optional `BEAR_TMP_DIR` / `BEAR_LOG_DIR` at process edge)
+- `bin/compile.php` using `Compiler::fromInjector()` + `run()` (`$tmpDir` / `$logDir` default to null = Meta paths)
 
 ### Changed
 - `Injector` builds `Meta` explicitly and accepts optional `$tmpDir` / `$logDir` (defaults unchanged)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.15.0] - 2026-07-10
+
+### Added
+- `bin/compile.php` using `Compiler::fromInjector()` + `run()` (optional `BEAR_TMP_DIR` / `BEAR_LOG_DIR` at process edge)
+
+### Changed
+- `Injector` builds `Meta` explicitly and accepts optional `$tmpDir` / `$logDir` (defaults unchanged)
+- Require `bear/app-meta` `^1.11` and `bear/package` `^1.21`
+- `composer compile` script uses `php bin/compile.php` instead of `bear.compile`
+
+## [1.14.0] - 2026-01-11
+
+### Added
+- security.yml, apidoc.yml, alps.yml workflows
+- Continuous integration triggers for push/PR
+
+### Changed
+- Workflows on PHP 8.5
+- Keep `.github` on project installation
+- psalm.xml taint analysis configuration
+
+[1.15.0]: https://github.com/bearsunday/BEAR.Skeleton/compare/1.14.0...1.15.0
+[1.14.0]: https://github.com/bearsunday/BEAR.Skeleton/compare/1.13.0...1.14.0

--- a/bin/compile.php
+++ b/bin/compile.php
@@ -16,4 +16,4 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 
 $context = $argv[1] ?? 'prod-app';
 
-exit(Compiler::fromInjector(Injector::getInstance($context), $context)->run());
+exit(Compiler::fromInjector(Injector::getInstance($context), $context)());

--- a/bin/compile.php
+++ b/bin/compile.php
@@ -1,0 +1,27 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CLI compile entry.
+ *
+ * Usage: php bin/compile.php [context]
+ * Optional env (process edge only): BEAR_TMP_DIR, BEAR_LOG_DIR
+ */
+
+use BEAR\Package\Compiler;
+use BEAR\Skeleton\Injector;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$context = $argv[1] ?? 'prod-app';
+$tmpDir = getenv('BEAR_TMP_DIR') ?: null;
+$logDir = getenv('BEAR_LOG_DIR') ?: null;
+
+exit(
+    Compiler::fromInjector(
+        Injector::getInstance($context, $tmpDir, $logDir),
+        $context,
+    )->run()
+);

--- a/bin/compile.php
+++ b/bin/compile.php
@@ -15,12 +15,5 @@ use BEAR\Skeleton\Injector;
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 $context = $argv[1] ?? 'prod-app';
-$tmpDir = null; // ={appDir}/var/tmp/{context}
-$logDir = null; // ={appDir}/var/log/{context}
 
-exit(
-    Compiler::fromInjector(
-        Injector::getInstance($context, $tmpDir, $logDir),
-        $context,
-    )->run()
-);
+exit(Compiler::fromInjector(Injector::getInstance($context), $context)->run());

--- a/bin/compile.php
+++ b/bin/compile.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
  * CLI compile entry.
  *
  * Usage: php bin/compile.php [context]
- * Optional env (process edge only): BEAR_TMP_DIR, BEAR_LOG_DIR
  */
 
 use BEAR\Package\Compiler;
@@ -16,8 +15,8 @@ use BEAR\Skeleton\Injector;
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 $context = $argv[1] ?? 'prod-app';
-$tmpDir = getenv('BEAR_TMP_DIR') ?: null;
-$logDir = getenv('BEAR_LOG_DIR') ?: null;
+$tmpDir = null; // ={appDir}/var/tmp/{context}
+$logDir = null; // ={appDir}/var/log/{context}
 
 exit(
     Compiler::fromInjector(

--- a/composer.json
+++ b/composer.json
@@ -105,13 +105,5 @@
             "bin-links": true,
             "forward-command": false
         }
-    },
-    "repositories": [{
-        "name": "app-meta",
-        "type": "path",
-        "url": "/Users/akihito/git/BEAR.AppMeta",
-        "options": {
-            "symlink": true
-        }
-    }]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "bear/skeleton",
     "type": "project",
-    "license":"proprietary",
-    "description": "Skeleton for BEAR.Sunday projects",
+    "license": "MIT",
+    "description": "Skeleton application for BEAR.Sunday",
     "require": {
         "php": "^8.1",
         "koriym/env-json": "^1.0",
@@ -19,7 +19,8 @@
         "bear/security": "^0.1",
         "bamarni/composer-bin-plugin": "^1.4",
         "composer/composer": "^2.1",
-        "phpunit/phpunit": "^10.5.38"
+        "phpunit/phpunit": "^10.0",
+        "roave/security-advisories": "dev-latest"
     },
     "autoload": {
         "psr-4": {
@@ -31,10 +32,17 @@
             "BEAR\\Skeleton\\": "tests/"
         }
     },
-    "scripts" :{
+    "scripts": {
         "pre-update-cmd": "BEAR\\Skeleton\\Composer::install",
-        "post-update-cmd": ["@composer update",  "@composer bin all update --ansi", "./finalyze.sh"],
-        "post-install-cmd": ["@setup", "@composer bin all install --ansi"],
+        "post-update-cmd": [
+            "@composer update",
+            "@composer bin all update --ansi",
+            "./finalyze.sh"
+        ],
+        "post-install-cmd": [
+            "@setup",
+            "@composer bin all install --ansi"
+        ],
         "setup": "php bin/setup.php",
         "compile": "php bin/compile.php prod-app",
         "doc": "./vendor/bin/apidoc",

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "require": {
         "php": "^8.1",
         "koriym/env-json": "^1.0",
+        "bear/app-meta": "^1.11",
         "bear/package": "^1.21",
         "bear/resource": "^1.17",
         "bear/sunday": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "bear/skeleton",
     "type": "project",
     "license":"MIT",
-    "description": "Skeleton application for BEAR.Sunday",
+    "description": "Skeleton for BEAR.Sunday projects",
     "require": {
         "php": "^8.1",
         "koriym/env-json": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "bear/security": "^0.1",
         "bamarni/composer-bin-plugin": "^1.4",
         "composer/composer": "^2.1",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^10.5.38"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "php": "^8.1",
         "koriym/env-json": "^1.0",
-        "bear/app-meta": "^1.11",
         "bear/package": "^1.21",
         "bear/resource": "^1.17",
         "bear/sunday": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bear/skeleton",
     "type": "project",
-    "license":"MIT",
+    "license":"proprietary",
     "description": "Skeleton for BEAR.Sunday projects",
     "require": {
         "php": "^8.1",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "php": "^8.1",
         "koriym/env-json": "^1.0",
-        "bear/package": "^1.14",
+        "bear/app-meta": "^1.11",
+        "bear/package": "^1.21",
         "bear/resource": "^1.17",
         "bear/sunday": "^1.6",
         "ray/aop": "^2.12",
@@ -35,7 +36,7 @@
         "post-update-cmd": ["@composer update",  "@composer bin all update --ansi", "./finalyze.sh"],
         "post-install-cmd": ["@setup", "@composer bin all install --ansi"],
         "setup": "php bin/setup.php",
-        "compile": "bear.compile 'BEAR\\Skeleton' prod-app ./",
+        "compile": "php bin/compile.php prod-app",
         "doc": "./vendor/bin/apidoc",
         "test": "./vendor/bin/phpunit",
         "coverage": "php -dzend_extension=xdebug.so -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage",
@@ -104,5 +105,13 @@
             "bin-links": true,
             "forward-command": false
         }
-    }
+    },
+    "repositories": [{
+        "name": "app-meta",
+        "type": "path",
+        "url": "/Users/akihito/git/BEAR.AppMeta",
+        "options": {
+            "symlink": true
+        }
+    }]
 }

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
         "bear/security": "^0.1",
         "bamarni/composer-bin-plugin": "^1.4",
         "composer/composer": "^2.1",
-        "phpunit/phpunit": "^10.0",
-        "roave/security-advisories": "dev-latest"
+        "phpunit/phpunit": "^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -50,11 +50,6 @@ final class Injector
         string|null $tmpDir,
         string|null $logDir,
     ): Meta {
-        $appDir = dirname(__DIR__);
-        if ($tmpDir === null && $logDir === null) {
-            return new Meta(__NAMESPACE__, $context, $appDir);
-        }
-
-        return new Meta(__NAMESPACE__, $context, $appDir, $tmpDir, $logDir);
+        return new Meta(__NAMESPACE__, $context, dirname(__DIR__), $tmpDir, $logDir);
     }
 }

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace BEAR\Skeleton;
 
-use BEAR\Package\Injector as PackageInjector;
+use BEAR\AppMeta\Meta;
+use BEAR\Package\Injector\PackageInjector;
 use Ray\Di\AbstractModule;
 use Ray\Di\InjectorInterface;
+use Ray\PsrCacheModule\LocalCacheProvider;
 
 use function dirname;
+use function str_replace;
 
 /** @SuppressWarnings("PHPMD.StaticAccess") */
 final class Injector
@@ -19,14 +22,23 @@ final class Injector
     }
 
     /** @param non-empty-string $context */
-    public static function getInstance(string $context): InjectorInterface
-    {
-        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__));
+    public static function getInstance(
+        string $context,
+        string|null $tmpDir = null,
+        string|null $logDir = null,
+    ): InjectorInterface {
+        $meta = new Meta(__NAMESPACE__, $context, dirname(__DIR__), $tmpDir, $logDir);
+        $cacheNamespace = str_replace('/', '_', $meta->appDir) . $context;
+        $cache = (new LocalCacheProvider($meta->tmpDir . '/injector', $cacheNamespace))->get();
+
+        return PackageInjector::getInstance($meta, $context, $cache);
     }
 
     /** @param non-empty-string $context */
     public static function getOverrideInstance(string $context, AbstractModule $overrideModule): InjectorInterface
     {
-        return PackageInjector::getOverrideInstance(__NAMESPACE__, $context, dirname(__DIR__), $overrideModule);
+        $meta = new Meta(__NAMESPACE__, $context, dirname(__DIR__));
+
+        return PackageInjector::factory($meta, $context, $overrideModule);
     }
 }

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace BEAR\Skeleton;
 
-use BEAR\Package\Injector as PackageInjector;
+use BEAR\AppMeta\Meta;
+use BEAR\Package\Injector\PackageInjector;
 use Ray\Di\AbstractModule;
 use Ray\Di\InjectorInterface;
+use Ray\PsrCacheModule\LocalCacheProvider;
 
 use function dirname;
+use function str_replace;
 
 /** @SuppressWarnings("PHPMD.StaticAccess") */
 final class Injector
@@ -19,14 +22,39 @@ final class Injector
     }
 
     /** @param non-empty-string $context */
-    public static function getInstance(string $context): InjectorInterface
-    {
-        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__));
+    public static function getInstance(
+        string $context,
+        string|null $tmpDir = null,
+        string|null $logDir = null,
+    ): InjectorInterface {
+        $meta = self::newMeta($context, $tmpDir, $logDir);
+        $cacheNamespace = str_replace('/', '_', $meta->appDir) . $context;
+        $cache = (new LocalCacheProvider($meta->tmpDir . '/injector', $cacheNamespace))->get();
+
+        return PackageInjector::getInstance($meta, $context, $cache);
     }
 
     /** @param non-empty-string $context */
-    public static function getOverrideInstance(string $context, AbstractModule $overrideModule): InjectorInterface
-    {
-        return PackageInjector::getOverrideInstance(__NAMESPACE__, $context, dirname(__DIR__), $overrideModule);
+    public static function getOverrideInstance(
+        string $context,
+        AbstractModule $overrideModule,
+        string|null $tmpDir = null,
+        string|null $logDir = null,
+    ): InjectorInterface {
+        return PackageInjector::factory(self::newMeta($context, $tmpDir, $logDir), $context, $overrideModule);
+    }
+
+    /** @param non-empty-string $context */
+    private static function newMeta(
+        string $context,
+        string|null $tmpDir,
+        string|null $logDir,
+    ): Meta {
+        $appDir = dirname(__DIR__);
+        if ($tmpDir === null && $logDir === null) {
+            return new Meta(__NAMESPACE__, $context, $appDir);
+        }
+
+        return new Meta(__NAMESPACE__, $context, $appDir, $tmpDir, $logDir);
     }
 }

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace BEAR\Skeleton;
 
-use BEAR\AppMeta\Meta;
-use BEAR\Package\Injector\PackageInjector;
+use BEAR\Package\Injector as PackageInjector;
 use Ray\Di\AbstractModule;
 use Ray\Di\InjectorInterface;
-use Ray\PsrCacheModule\LocalCacheProvider;
 
 use function dirname;
-use function str_replace;
 
 /** @SuppressWarnings("PHPMD.StaticAccess") */
 final class Injector
@@ -22,34 +19,14 @@ final class Injector
     }
 
     /** @param non-empty-string $context */
-    public static function getInstance(
-        string $context,
-        string|null $tmpDir = null, // ={appDir}/var/tmp/{context}
-        string|null $logDir = null, // ={appDir}/var/log/{context}
-    ): InjectorInterface {
-        $meta = self::newMeta($context, $tmpDir, $logDir);
-        $cacheNamespace = str_replace('/', '_', $meta->appDir) . $context;
-        $cache = (new LocalCacheProvider($meta->tmpDir . '/injector', $cacheNamespace))->get();
-
-        return PackageInjector::getInstance($meta, $context, $cache);
+    public static function getInstance(string $context): InjectorInterface
+    {
+        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__));
     }
 
     /** @param non-empty-string $context */
-    public static function getOverrideInstance(
-        string $context,
-        AbstractModule $overrideModule,
-        string|null $tmpDir = null, // ={appDir}/var/tmp/{context}
-        string|null $logDir = null, // ={appDir}/var/log/{context}
-    ): InjectorInterface {
-        return PackageInjector::factory(self::newMeta($context, $tmpDir, $logDir), $context, $overrideModule);
-    }
-
-    /** @param non-empty-string $context */
-    private static function newMeta(
-        string $context,
-        string|null $tmpDir,
-        string|null $logDir,
-    ): Meta {
-        return new Meta(__NAMESPACE__, $context, dirname(__DIR__), $tmpDir, $logDir);
+    public static function getOverrideInstance(string $context, AbstractModule $overrideModule): InjectorInterface
+    {
+        return PackageInjector::getOverrideInstance(__NAMESPACE__, $context, dirname(__DIR__), $overrideModule);
     }
 }

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -24,8 +24,8 @@ final class Injector
     /** @param non-empty-string $context */
     public static function getInstance(
         string $context,
-        string|null $tmpDir = null,
-        string|null $logDir = null,
+        string|null $tmpDir = null, // ={appDir}/var/tmp/{context}
+        string|null $logDir = null, // ={appDir}/var/log/{context}
     ): InjectorInterface {
         $meta = self::newMeta($context, $tmpDir, $logDir);
         $cacheNamespace = str_replace('/', '_', $meta->appDir) . $context;
@@ -38,8 +38,8 @@ final class Injector
     public static function getOverrideInstance(
         string $context,
         AbstractModule $overrideModule,
-        string|null $tmpDir = null,
-        string|null $logDir = null,
+        string|null $tmpDir = null, // ={appDir}/var/tmp/{context}
+        string|null $logDir = null, // ={appDir}/var/log/{context}
     ): InjectorInterface {
         return PackageInjector::factory(self::newMeta($context, $tmpDir, $logDir), $context, $overrideModule);
     }


### PR DESCRIPTION
## Summary

- `Injector` builds `Meta` and accepts optional `$tmpDir` / `$logDir` (defaults unchanged)
- Add `bin/compile.php` via `Compiler::fromInjector()` + `run()`; null means Meta defaults
- Require `bear/app-meta` `^1.11` and `bear/package` `^1.21`
- Add CHANGELOG for **1.15.0**

## Depends on

1. bearsunday/BEAR.AppMeta#41 → **1.11.0**
2. bearsunday/BEAR.Package#480 → **1.21.0**

## Test plan

- [ ] After package/meta releases: `composer update` on a fresh create-project
- [ ] `composer compile` succeeds without header warnings
- [ ] Default paths remain `var/tmp/{context}` / `var/log/{context}`
- [ ] Absolute paths passed to `Injector::getInstance` override Meta paths when needed