### PR TITLE
Load .compile.php in bin/compile.php when present

### DIFF
--- a/bin/compile.php
+++ b/bin/compile.php
@@ -7,12 +7,18 @@ declare(strict_types=1);
  * CLI compile entry.
  *
  * Usage: php bin/compile.php [context]
+ *
+ * @see https://bearsunday.github.io/manuals/1.0/en/production.html#compilation
  */
 
 use BEAR\Package\Compiler;
 use BEAR\Skeleton\Injector;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
+
+// Load build-time-only stubs (null objects / fake env) if present.
+$dotCompile = dirname(__DIR__) . '/.compile.php';
+is_file($dotCompile) && require $dotCompile;
 
 $context = $argv[1] ?? 'prod-app';
 


### PR DESCRIPTION
## Summary

`Compiler::fromInjector()` (the recommended compile entry since BEAR.Package 1.21, see bearsunday/BEAR.Package#482) does **not** auto-load the root `.compile.php` the way the deprecated `bear.compile` did. Compile re-instantiates every resource via `loadResources()`, so any app whose resources need build-time-only null objects / fake env (auth, DB, Redis, external APIs) would fail to compile — or silently bake wrong values — after migrating to `bin/compile.php`.

This loads `.compile.php` explicitly, guarded by `is_file()` so it is a no-op when absent. It runs **before** `Injector::getInstance()` so both the passed injector and the internal `factory()` rebuild see the stubs.

## Notes

- No-op for the skeleton itself (it ships no `.compile.php`).
- Apps that need build stubs just drop a root `.compile.php` — no edit to `bin/compile.php` required.
- Manual updated in parallel (`production.md` `.compile.php` section) in bearsunday/bearsunday.github.io.

Refs bearsunday/BEAR.Package#482, bearsunday/BEAR.Package#483

🤖 Generated with [Claude Code](https://claude.com/claude-code)
