### PR TITLE
Generate the bin/compile.php compile entry on project installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `src/Install.php` injects `php bin/compile.php prod-app` as the `compile` script into created projects, instead of the deprecated `vendor/bin/bear.compile`
+
 ## [1.15.0] - 2026-07-10
 
 ### Added

--- a/src/Install.php
+++ b/src/Install.php
@@ -107,7 +107,7 @@ final class Install
             'description' => '',
             'autoload' => ['psr-4' => ["{$vendor}\\{$package}\\" => 'src/']],
             'autoload-dev' => ['psr-4' => ["{$vendor}\\{$package}\\" => 'tests/']],
-            'scripts' => array_merge($composerJson['scripts'], ['compile' => "./vendor/bin/bear.compile '{$vendor}\\{$package}' prod-app ./"]),
+            'scripts' => array_merge($composerJson['scripts'], ['compile' => 'php bin/compile.php prod-app']),
         ]);
         unset(
             $composerJson['autoload']['files'],


### PR DESCRIPTION
## Summary

`src/Install.php` injected the deprecated `./vendor/bin/bear.compile '<Vendor>\<Package>' prod-app ./` into the `composer.json` of **every newly created project**, even though the skeleton's own compile script was migrated in 1.15.0 and `bin/compile.php` ships with the template. Fresh projects therefore started on the deprecated path and printed the BEAR.Package deprecation notice (bearsunday/BEAR.Package#481) on their first `composer compile`.

The installer now generates:

```json
"compile": "php bin/compile.php prod-app"
```

matching the shipped `bin/compile.php` entry (`Compiler::fromInjector`) and the production manual. See bearsunday/BEAR.Package#482 for the migration guide.

## Test plan

- [x] phpcs clean
- [x] phpunit OK (3 tests, 4 assertions)
- [x] `bin/compile.php` ships in the template and is namespace-renamed by the installer (`recursiveJob` covers `*.php`), so created projects need no other change

Refs: bearsunday/BEAR.Package#481 (comment: migration sequencing checklist)
