### PR TITLE
Call router->match() inside the try

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `Bootstrap` calls `router->match()` inside its `try`, so a malformed request answers through the error handler instead of an uncaught fatal (bearsunday/BEAR.Package#493)
+
 ## [1.15.0] - 2026-07-10
 
 ### Added

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -35,7 +35,6 @@ final class Bootstrap
             return 0;
         }
 
-        // match() throws BadRequestException on client input it cannot read.
         $request = new NullMatch();
         try {
             $request = $app->router->match($globals, $server);

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -7,6 +7,7 @@ namespace BEAR\Skeleton;
 use BEAR\Resource\ResourceObject;
 use BEAR\Skeleton\Module\App;
 use BEAR\Sunday\Extension\Application\AppInterface;
+use BEAR\Sunday\Extension\Router\NullMatch;
 use BEAR\Sunday\Extension\Router\RouterInterface;
 use Throwable;
 
@@ -34,8 +35,11 @@ final class Bootstrap
             return 0;
         }
 
-        $request = $app->router->match($globals, $server);
+        // The router reads the request line, so it fails on client input: a request URI with no
+        // path, or a JSON body that does not parse. Those answer 4xx only if the handler sees them.
+        $request = new NullMatch();
         try {
+            $request = $app->router->match($globals, $server);
             $response = $app->resource->{$request->method}->uri($request->path)($request->query);
             assert($response instanceof ResourceObject);
             $response->transfer($app->responder, $server);

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -35,8 +35,7 @@ final class Bootstrap
             return 0;
         }
 
-        // The router reads the request line, so it fails on client input: a request URI with no
-        // path, or a JSON body that does not parse. Those answer 4xx only if the handler sees them.
+        // match() throws BadRequestException on client input it cannot read.
         $request = new NullMatch();
         try {
             $request = $app->router->match($globals, $server);


### PR DESCRIPTION
`src/Bootstrap.php` called `$app->router->match()` outside its `try`. The router reads the request line, so it fails on client input: BEAR.Package throws `BadRequestException` subclasses from `match()` for a request URI with no path (`InvalidRequestUriException`, bearsunday/BEAR.Package#493) and for a JSON body that does not parse (`InvalidRequestJsonException`, which has done so far longer). Outside the `try` those are uncaught: PHP answers a fatal, `throwableHandler` never runs, and the response has no body.

```text
PHP Fatal error:  Uncaught BEAR\Package\Exception\InvalidRequestJsonException: Syntax error
#3 vendor/bear/package/src/Provide/Router/WebRouter.php(51): HttpMethodParams->get(Array, Array, Array)
#4 src/Bootstrap.php(37): WebRouter->match(Array, Array)
#5 public/index.php(8): MyVendor\MyProject\Bootstrap->__invoke('hal-app', Array, Array)
```

Measured on this skeleton, `zend.assertions` both `-1` and `1`, four isolated installs so no shared `var/tmp` or opcache state:

| | `GET /` | `GET //` | `GET ///` | `POST` bad JSON |
|---|---|---|---|---|
| before | 200 | 500 | 500 | 500 |
| after | 200 | 400 | 400 | 400 |

and it logs at DEBUG rather than ERROR, so a malformed request no longer pages an operator:

```text
DEBUG: req:" " code:400 e:BEAR\Package\Exception\InvalidRequestUriException(No path in request URI "//".) logref:6742768e
```

`$request` is seeded with `NullMatch` because `throwableHandler->handle()` needs a request and the router may not have produced one. It stringifies to nothing, which is honest - no route was resolved - and the exception message carries the offending URI.

### Notes

- The 400 needs the router change in bearsunday/BEAR.Package#494. With `bear/package` as currently required, this commit still helps and cannot regress: in development an `AssertionError` from `match()` reached the client as a fatal, and now the error handler answers it.
- All four entry points (`public/index.php`, `bin/app.php`, `bin/page.php`, `tests/Http/index.php`) delegate here, so this is the only file that needed it.
- No test: `HttpResource` has no raw-URI client, and a template is the wrong place for the machinery. The behaviour is covered by `WebRouterTest` and `RouterCollectionTest` in BEAR.Package.

`composer tests` passes on the installed project: phpcs, Psalm, PHPStan, 3 tests.