### PR TITLE
Take a write directory, for an application directory that is read-only

### DIFF
--- a/bin/app.php
+++ b/bin/app.php
@@ -5,4 +5,4 @@ declare(strict_types=1);
 use BEAR\Skeleton\Bootstrap;
 
 require dirname(__DIR__) . '/autoload.php';
-exit((new Bootstrap())(PHP_SAPI === 'cli' ? 'cli-hal-api-app' : 'hal-api-app', $GLOBALS, $_SERVER));
+exit((new Bootstrap())(PHP_SAPI === 'cli' ? 'cli-hal-api-app' : 'hal-api-app', $GLOBALS, $_SERVER, getenv('APP_WRITE_DIR') ?: null));

--- a/bin/compile.php
+++ b/bin/compile.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  *
  * Usage: php bin/compile.php [context]
  *
- * @see https://bearsunday.github.io/manuals/1.0/en/production.html#compilation
+ * @see https://bearsunday.github.io/manuals/1.0/en/production.html#compilation-recommended
  */
 
 use BEAR\Package\Compiler;
@@ -21,5 +21,6 @@ $dotCompile = dirname(__DIR__) . '/.compile.php';
 is_file($dotCompile) && require $dotCompile;
 
 $context = $argv[1] ?? 'prod-app';
+$writeDir = getenv('APP_WRITE_DIR') ?: null;
 
-exit(Compiler::fromInjector(Injector::getInstance($context), $context)());
+exit(Compiler::fromInjector(Injector::getInstance($context, $writeDir), $context, $writeDir)());

--- a/bin/page.php
+++ b/bin/page.php
@@ -5,4 +5,4 @@ declare(strict_types=1);
 use BEAR\Skeleton\Bootstrap;
 
 require dirname(__DIR__) . '/autoload.php';
-exit((new Bootstrap())(PHP_SAPI === 'cli' ? 'cli-hal-app' : 'hal-app', $GLOBALS, $_SERVER));
+exit((new Bootstrap())(PHP_SAPI === 'cli' ? 'cli-hal-app' : 'hal-app', $GLOBALS, $_SERVER, getenv('APP_WRITE_DIR') ?: null));

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.1",
         "koriym/env-json": "^1.0",
         "bear/app-meta": "^1.11",
-        "bear/package": "^1.21",
+        "bear/package": "^1.22",
         "bear/resource": "^1.17",
         "bear/sunday": "^1.6",
         "ray/aop": "^2.12",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "description": "Skeleton application for BEAR.Sunday",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "koriym/env-json": "^1.0",
         "bear/app-meta": "^1.11",
         "bear/package": "^1.22",

--- a/public/index.php
+++ b/public/index.php
@@ -5,4 +5,4 @@ declare(strict_types=1);
 use BEAR\Skeleton\Bootstrap;
 
 require dirname(__DIR__) . '/autoload.php';
-exit((new Bootstrap())(PHP_SAPI === 'cli-server' ? 'hal-app' : 'prod-hal-app', $GLOBALS, $_SERVER));
+exit((new Bootstrap())(PHP_SAPI === 'cli-server' ? 'hal-app' : 'prod-hal-app', $GLOBALS, $_SERVER, getenv('APP_WRITE_DIR') ?: null));

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -19,14 +19,15 @@ use function assert;
 final class Bootstrap
 {
     /**
-     * @param Globals $globals
-     * @param Server  $server
+     * @param Globals               $globals
+     * @param Server                $server
+     * @param non-empty-string|null $writeDir absolute base to write under, when this directory is read-only
      *
      * @return 0|1
      */
-    public function __invoke(string $context, array $globals, array $server): int
+    public function __invoke(string $context, array $globals, array $server, string|null $writeDir = null): int
     {
-        $app = Injector::getInstance($context)->getInstance(AppInterface::class);
+        $app = Injector::getInstance($context, $writeDir)->getInstance(AppInterface::class);
         assert($app instanceof App);
         if ($app->httpCache->isNotModified($server)) {
             $app->httpCache->transfer();

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace BEAR\Skeleton;
 
-use BEAR\AppMeta\Meta;
-use BEAR\Package\Injector\PackageInjector;
+use BEAR\Package\Injector as PackageInjector;
 use Ray\Di\AbstractModule;
 use Ray\Di\InjectorInterface;
-use Ray\PsrCacheModule\LocalCacheProvider;
 
 use function dirname;
-use function str_replace;
 
 /** @SuppressWarnings("PHPMD.StaticAccess") */
 final class Injector
@@ -21,24 +18,18 @@ final class Injector
     {
     }
 
-    /** @param non-empty-string $context */
-    public static function getInstance(
-        string $context,
-        string|null $tmpDir = null,
-        string|null $logDir = null,
-    ): InjectorInterface {
-        $meta = new Meta(__NAMESPACE__, $context, dirname(__DIR__), $tmpDir, $logDir);
-        $cacheNamespace = str_replace('/', '_', $meta->appDir) . $context;
-        $cache = (new LocalCacheProvider($meta->tmpDir . '/injector', $cacheNamespace))->get();
-
-        return PackageInjector::getInstance($meta, $context, $cache);
+    /**
+     * @param non-empty-string      $context
+     * @param non-empty-string|null $writeDir absolute base to write under, when this directory is read-only
+     */
+    public static function getInstance(string $context, string|null $writeDir = null): InjectorInterface
+    {
+        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__), null, $writeDir);
     }
 
     /** @param non-empty-string $context */
     public static function getOverrideInstance(string $context, AbstractModule $overrideModule): InjectorInterface
     {
-        $meta = new Meta(__NAMESPACE__, $context, dirname(__DIR__));
-
-        return PackageInjector::factory($meta, $context, $overrideModule);
+        return PackageInjector::getOverrideInstance(__NAMESPACE__, $context, dirname(__DIR__), $overrideModule);
     }
 }


### PR DESCRIPTION
An application directory can be read-only — a container image, a Phar archive — so the entries take a write directory.

`Injector::getInstance($context, $writeDir)` and `Bootstrap::__invoke(..., $writeDir)` pass it on. `public/index.php`, `bin/app.php` and `bin/page.php` read `APP_WRITE_DIR`; `bin/compile.php` passes the same one to the injector and to `Compiler::fromInjector()`, so the build and the boot derive the same paths. Without the variable nothing changes: the application writes under its own `var/`.

`Injector` delegates to `BEAR\Package\Injector`, which has placed the `Meta` and wired the cache since 1.22 — the copy here predated it, and its `$tmpDir`/`$logDir` arguments are what a write directory replaces. Requires `bear/package: ^1.22`.

Refs [bearsunday/BEAR.Package#426](https://github.com/bearsunday/BEAR.Package/issues/426).
