### PR TITLE
Stop passing a write directory to the boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- `bin/compile.php` builds the compiler directly: `new Compiler('BEAR\Skeleton', $context, dirname(__DIR__), $writeDir)`. `Compiler::fromInjector()` is gone in `bear/package` 1.24
+- `bin/compile.php` builds the compiler directly: `new Compiler('BEAR\Skeleton', $context, dirname(__DIR__))`. `Compiler::fromInjector()` is gone in `bear/package` 1.24
+
+### Removed
+- `APP_WRITE_DIR`, and the write directory the entries took: an application declares where it writes in its own `ProdModule`, with `BEAR\Package\Module\ReadOnlyAppModule`
 
 ## [1.16.0] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- `bin/compile.php` builds the compiler directly: `new Compiler('BEAR\Skeleton', $context, dirname(__DIR__), $writeDir)`. `Compiler::fromInjector()` is gone in `bear/package` 1.24
+
 ## [1.16.0] - 2026-08-17
 
 An application directory can be read-only - a container image, a Phar archive - so the entries take a

--- a/bin/app.php
+++ b/bin/app.php
@@ -5,4 +5,4 @@ declare(strict_types=1);
 use BEAR\Skeleton\Bootstrap;
 
 require dirname(__DIR__) . '/autoload.php';
-exit((new Bootstrap())(PHP_SAPI === 'cli' ? 'cli-hal-api-app' : 'hal-api-app', $GLOBALS, $_SERVER, getenv('APP_WRITE_DIR') ?: null));
+exit((new Bootstrap())(PHP_SAPI === 'cli' ? 'cli-hal-api-app' : 'hal-api-app', $GLOBALS, $_SERVER));

--- a/bin/compile.php
+++ b/bin/compile.php
@@ -15,10 +15,7 @@ use BEAR\Package\Compiler;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-// Load build-time-only stubs (null objects / fake env) if present.
-$dotCompile = dirname(__DIR__) . '/.compile.php';
-is_file($dotCompile) && require $dotCompile;
-
+// Compiler itself loads .compile.php (build-time-only stubs) if present.
 $context = $argv[1] ?? 'prod-app';
 
 exit((new Compiler('BEAR\Skeleton', $context, dirname(__DIR__)))());

--- a/bin/compile.php
+++ b/bin/compile.php
@@ -20,6 +20,5 @@ $dotCompile = dirname(__DIR__) . '/.compile.php';
 is_file($dotCompile) && require $dotCompile;
 
 $context = $argv[1] ?? 'prod-app';
-$writeDir = getenv('APP_WRITE_DIR') ?: null;
 
-exit((new Compiler('BEAR\Skeleton', $context, dirname(__DIR__), $writeDir))());
+exit((new Compiler('BEAR\Skeleton', $context, dirname(__DIR__)))());

--- a/bin/compile.php
+++ b/bin/compile.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
  */
 
 use BEAR\Package\Compiler;
-use BEAR\Skeleton\Injector;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
@@ -23,4 +22,4 @@ is_file($dotCompile) && require $dotCompile;
 $context = $argv[1] ?? 'prod-app';
 $writeDir = getenv('APP_WRITE_DIR') ?: null;
 
-exit(Compiler::fromInjector(Injector::getInstance($context, $writeDir), $context, $writeDir)());
+exit((new Compiler('BEAR\Skeleton', $context, dirname(__DIR__), $writeDir))());

--- a/bin/page.php
+++ b/bin/page.php
@@ -5,4 +5,4 @@ declare(strict_types=1);
 use BEAR\Skeleton\Bootstrap;
 
 require dirname(__DIR__) . '/autoload.php';
-exit((new Bootstrap())(PHP_SAPI === 'cli' ? 'cli-hal-app' : 'hal-app', $GLOBALS, $_SERVER, getenv('APP_WRITE_DIR') ?: null));
+exit((new Bootstrap())(PHP_SAPI === 'cli' ? 'cli-hal-app' : 'hal-app', $GLOBALS, $_SERVER));

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.2",
         "koriym/env-json": "^1.0",
         "bear/app-meta": "^1.11",
-        "bear/package": "^1.22",
+        "bear/package": "^1.24",
         "bear/resource": "^1.17",
         "bear/sunday": "^1.6",
         "ray/aop": "^2.12",

--- a/public/index.php
+++ b/public/index.php
@@ -5,4 +5,4 @@ declare(strict_types=1);
 use BEAR\Skeleton\Bootstrap;
 
 require dirname(__DIR__) . '/autoload.php';
-exit((new Bootstrap())(PHP_SAPI === 'cli-server' ? 'hal-app' : 'prod-hal-app', $GLOBALS, $_SERVER, getenv('APP_WRITE_DIR') ?: null));
+exit((new Bootstrap())(PHP_SAPI === 'cli-server' ? 'hal-app' : 'prod-hal-app', $GLOBALS, $_SERVER));

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -21,13 +21,12 @@ final class Bootstrap
     /**
      * @param Globals               $globals
      * @param Server                $server
-     * @param non-empty-string|null $writeDir absolute base to write under, when this directory is read-only
      *
      * @return 0|1
      */
-    public function __invoke(string $context, array $globals, array $server, string|null $writeDir = null): int
+    public function __invoke(string $context, array $globals, array $server): int
     {
-        $app = Injector::getInstance($context, $writeDir)->getInstance(AppInterface::class);
+        $app = Injector::getInstance($context)->getInstance(AppInterface::class);
         assert($app instanceof App);
         if ($app->httpCache->isNotModified($server)) {
             $app->httpCache->transfer();

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -19,8 +19,8 @@ use function assert;
 final class Bootstrap
 {
     /**
-     * @param Globals               $globals
-     * @param Server                $server
+     * @param Globals $globals
+     * @param Server  $server
      *
      * @return 0|1
      */

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -18,9 +18,7 @@ final class Injector
     {
     }
 
-    /**
-     * @param non-empty-string $context
-     */
+    /** @param non-empty-string $context */
     public static function getInstance(string $context): InjectorInterface
     {
         return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__));

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -19,12 +19,11 @@ final class Injector
     }
 
     /**
-     * @param non-empty-string      $context
-     * @param non-empty-string|null $writeDir absolute base to write under, when this directory is read-only
+     * @param non-empty-string $context
      */
-    public static function getInstance(string $context, string|null $writeDir = null): InjectorInterface
+    public static function getInstance(string $context): InjectorInterface
     {
-        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__), null, $writeDir);
+        return PackageInjector::getInstance(__NAMESPACE__, $context, dirname(__DIR__));
     }
 
     /** @param non-empty-string $context */


### PR DESCRIPTION
BEAR.Package no longer takes one. An application declares where it writes in its own
`ProdModule`, with `ReadOnlyAppModule`, and the declaration is compiled into the container
that ships with the scripts — see bearsunday/BEAR.Package#511.

`APP_WRITE_DIR` goes from `public/index.php`, `bin/app.php`, `bin/page.php` and
`bin/compile.php`, and `$writeDir` from `Injector::getInstance()` and `Bootstrap::__invoke()`.

This skeleton adds no `ProdModule`: a tree that is writable needs no declaration. Packing one
into an archive without it is refused at build time, naming the directory it would have
written into.

Needs BEAR.Package to release the change first.